### PR TITLE
Add walls

### DIFF
--- a/app/src/main/java/com/tavarus/artabletop/Board.kt
+++ b/app/src/main/java/com/tavarus/artabletop/Board.kt
@@ -10,13 +10,19 @@ import com.google.ar.sceneform.rendering.ShapeFactory
 import com.google.ar.sceneform.Node
 
 
-class Board (private val width: Int,private val height: Int, private val size: Float, context: Context) {
+class Board (private val width: Int, private val height: Int, private val size: Float, context: Context) {
     private var tileRenderable: ModelRenderable? = null
+    private var xWall: ModelRenderable? = null
+    private var yWall: ModelRenderable? = null
+
 
     init {
         MaterialFactory.makeOpaqueWithColor(context, com.google.ar.sceneform.rendering.Color(Color.BLACK))
             .thenAccept { material ->
-                tileRenderable = ShapeFactory.makeCube(Vector3(0.96f * size,0.01f,0.96f * size), Vector3(0f,0.1f,0f),material)
+                tileRenderable = ShapeFactory.makeCube(Vector3(0.96f * size,0.01f,0.96f * size), Vector3(0f,0f,0f),material)
+                xWall = ShapeFactory.makeCube(Vector3(0.96f * size,size ,0.08f * size), Vector3(0f,0f,0f),material)
+                yWall = ShapeFactory.makeCube(Vector3(0.08f * size,size ,0.96f * size), Vector3(0f,0f,0f),material)
+
             }
     }
 
@@ -28,8 +34,33 @@ class Board (private val width: Int,private val height: Int, private val size: F
             val y = 0f - ((height * size - size) / 2) + (index.div(height) * size)
             tile.setParent(base)
             tile.renderable = tileRenderable
-            tile.localPosition = Vector3(x, 0.1f, y)
+            tile.localPosition = Vector3(x, 0f, y)
         }
+        addWalls(base, arrayOf(0, 3, 8), arrayOf(0, 3, 8))
         return base
+    }
+
+    fun addWalls(base: Node, xWalls: Array<Int>, yWalls: Array<Int>) {
+        for (wallIndex in xWalls) {
+            if (wallIndex < (height + 1) * width) {
+                val wall = Node()
+                val x = 0f - ((width * size - size) / 2) + (wallIndex.rem(width) * size)
+                val y = 0f - ((height * size) / 2) + (wallIndex.div(height) * size)
+                wall.setParent(base)
+                wall.renderable = xWall
+                wall.localPosition = Vector3(x, size/2, y)
+            }
+        }
+
+        for (wallIndex in yWalls) {
+            if (wallIndex < height * (width + 1)) {
+                val wall = Node()
+                val x = 0f - ((width * size) / 2) + (wallIndex.div(width) * size)
+                val y = 0f - ((height * size - size) / 2) + (wallIndex.rem(height) * size)
+                wall.setParent(base)
+                wall.renderable = yWall
+                wall.localPosition = Vector3(x, size/2, y)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/tavarus/artabletop/Board.kt
+++ b/app/src/main/java/com/tavarus/artabletop/Board.kt
@@ -10,7 +10,14 @@ import com.google.ar.sceneform.rendering.ShapeFactory
 import com.google.ar.sceneform.Node
 
 
-class Board (private val width: Int, private val height: Int, private val size: Float, context: Context) {
+class Board (
+    private val width: Int,
+    private val height: Int,
+    private val size: Float,
+    private val xWalls: Array<Int>,
+    private val yWalls: Array<Int>,
+    context: Context
+) {
     private var tileRenderable: ModelRenderable? = null
     private var xWall: ModelRenderable? = null
     private var yWall: ModelRenderable? = null
@@ -20,14 +27,15 @@ class Board (private val width: Int, private val height: Int, private val size: 
         MaterialFactory.makeOpaqueWithColor(context, com.google.ar.sceneform.rendering.Color(Color.BLACK))
             .thenAccept { material ->
                 tileRenderable = ShapeFactory.makeCube(Vector3(0.96f * size,0.01f,0.96f * size), Vector3(0f,0f,0f),material)
-                xWall = ShapeFactory.makeCube(Vector3(0.96f * size,size ,0.08f * size), Vector3(0f,0f,0f),material)
-                yWall = ShapeFactory.makeCube(Vector3(0.08f * size,size ,0.96f * size), Vector3(0f,0f,0f),material)
+                xWall = ShapeFactory.makeCube(Vector3(size, size , 0.08f * size), Vector3(0f,0f,0f),material)
+                yWall = ShapeFactory.makeCube(Vector3(0.08f * size, size , size), Vector3(0f,0f,0f),material)
 
             }
     }
 
     fun boardNode(): Node {
         val base = Node()
+        base.localPosition = Vector3(0f, 0.2f, 0f)
         for (index in 0 until height * width) {
             val tile = Node()
             val x = 0f - ((width * size - size) / 2) + (index.rem(width) * size)
@@ -36,11 +44,7 @@ class Board (private val width: Int, private val height: Int, private val size: 
             tile.renderable = tileRenderable
             tile.localPosition = Vector3(x, 0f, y)
         }
-        addWalls(base, arrayOf(0, 3, 8), arrayOf(0, 3, 8))
-        return base
-    }
 
-    fun addWalls(base: Node, xWalls: Array<Int>, yWalls: Array<Int>) {
         for (wallIndex in xWalls) {
             if (wallIndex < (height + 1) * width) {
                 val wall = Node()
@@ -62,5 +66,7 @@ class Board (private val width: Int, private val height: Int, private val size: 
                 wall.localPosition = Vector3(x, size/2, y)
             }
         }
+        return base
     }
+
 }

--- a/app/src/main/java/com/tavarus/artabletop/MainActivity.kt
+++ b/app/src/main/java/com/tavarus/artabletop/MainActivity.kt
@@ -20,7 +20,8 @@ class MainActivity : AppCompatActivity() {
 
         arFragment = supportFragmentManager.findFragmentById(R.id.ux_fragment) as ArFragment?
 
-        board = Board(5, 5, 0.15f, this)
+        board = Board(6, 6, 0.15f, arrayOf(0, 1, 2, 6, 7, 21, 22, 32, 33, 33, 34),
+            arrayOf(13, 14, 15, 16, 18, 19, 20, 33, 34) ,this)
 
         arFragment!!.setOnTapArPlaneListener { hitResult: HitResult, plane: Plane, motionEvent: MotionEvent ->
             // Create the Anchor.


### PR DESCRIPTION
Added in walls. Currently wall position is defined as an array of ints for x, and an array of ints for y, where the int represents the position of the wall if every possible position for a wall of that orientation was numbered sequentially. This means that each piece of wall only needs to be stored as one piece of data, but it presents some issues:
1. If you make the board bigger or smaller, each position needs to be recalculated.
2. We need two separate arrays, one for walls with an x orientation and one for walls with a y orientation.
3. It's hard to discern the position of the walls as a human looking at the list.
It works currently though, and it shouldn't be too big of an issue to refactor in the future, as long as we do so before storing data in the back end.
This closes issue #2 