### PR TITLE
Separate out proper dagger components and fix navigation to board.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/app/src/main/java/com/tavarus/artabletop/App.kt
+++ b/app/src/main/java/com/tavarus/artabletop/App.kt
@@ -1,25 +1,17 @@
 package com.tavarus.artabletop
 
 import android.app.Application
-import com.tavarus.artabletop.CoreComponent
-import com.tavarus.artabletop.DaggerCoreComponent
 import com.tavarus.artabletop.models.BoardRepoModule
 import com.tavarus.artabletop.models.NavigationModule
+import com.tavarus.artabletop.modules.CoreAppModule
 
 class App: Application() {
 
     private val coreComponent: CoreComponent = DaggerCoreComponent.builder()
-        .navigationModule(NavigationModule)
-        .context(this)
-        .build()
-
-    private val boardComponent: BoardComponent = DaggerBoardComponent.builder()
-        .boardRepoModule(BoardRepoModule)
+        .coreAppModule(CoreAppModule)
         .context(this)
         .build()
 
     fun provideCoreComponent(): CoreComponent = coreComponent
-
-    fun provideBoardComponent(): BoardComponent = boardComponent
 
 }

--- a/app/src/main/java/com/tavarus/artabletop/BoardComponent.kt
+++ b/app/src/main/java/com/tavarus/artabletop/BoardComponent.kt
@@ -1,27 +1,15 @@
 package com.tavarus.artabletop
 
-import android.content.Context
 import com.tavarus.artabletop.fragments.BoardFragment
 import com.tavarus.artabletop.fragments.HomeFragment
 import com.tavarus.artabletop.models.BoardRepoModule
-import dagger.BindsInstance
-import dagger.Component
-import javax.inject.Singleton
+import dagger.Subcomponent
 
-@Singleton
-@Component(modules = [BoardRepoModule::class])
-interface BoardComponent {
+@BoardScope
+@Subcomponent(modules = [BoardRepoModule::class])
+interface BoardComponent: DaggerComponent {
 
     fun inject(homeFragment: HomeFragment)
 
     fun inject(boardFragment: BoardFragment)
-
-    @Component.Builder
-    interface Builder{
-        fun build() : BoardComponent
-        fun boardRepoModule(module: BoardRepoModule) : Builder
-
-        @BindsInstance
-        fun context(context: Context) : Builder
-    }
 }

--- a/app/src/main/java/com/tavarus/artabletop/BoardScope.kt
+++ b/app/src/main/java/com/tavarus/artabletop/BoardScope.kt
@@ -1,0 +1,7 @@
+package com.tavarus.artabletop
+
+import javax.inject.Scope
+
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+annotation class BoardScope

--- a/app/src/main/java/com/tavarus/artabletop/ComponentManager.kt
+++ b/app/src/main/java/com/tavarus/artabletop/ComponentManager.kt
@@ -1,0 +1,37 @@
+package com.tavarus.artabletop
+
+import android.content.Context
+import com.tavarus.artabletop.models.BoardRepoModule
+import com.tavarus.artabletop.models.NavigationModule
+
+class ComponentManager {
+    var componentMap = mutableMapOf<String, DaggerComponent>()
+
+    val BOARD_KEY = "BOARD_KEY"
+    val NAV_KEY = "NAV_KEY"
+
+    fun getOrCreateBoardComponent(context: Context, coreComponent: CoreComponent) : BoardComponent {
+        return if (componentMap.containsKey(BOARD_KEY)) {
+            componentMap[BOARD_KEY] as BoardComponent
+        } else {
+            val navComponent = getOrCreateNavComponent(context, coreComponent)
+            val daggerBoard = navComponent.plus(BoardRepoModule)
+            componentMap[BOARD_KEY] = daggerBoard
+            daggerBoard
+        }
+    }
+
+    fun getOrCreateNavComponent(context: Context, coreComponent: CoreComponent) : NavComponent {
+        return if (componentMap.containsKey(NAV_KEY)) {
+            componentMap[NAV_KEY] as NavComponent
+        } else {
+            val daggerNav = DaggerNavComponent.builder()
+                .navigationModule(NavigationModule)
+                .coreComponent(coreComponent)
+                .context(context)
+                .build()
+            componentMap[NAV_KEY] = daggerNav
+            daggerNav
+        }
+    }
+}

--- a/app/src/main/java/com/tavarus/artabletop/CoreComponent.kt
+++ b/app/src/main/java/com/tavarus/artabletop/CoreComponent.kt
@@ -1,30 +1,22 @@
 package com.tavarus.artabletop
 
 import android.content.Context
-import com.tavarus.artabletop.fragments.BoardFragment
-import com.tavarus.artabletop.fragments.HomeFragment
-import com.tavarus.artabletop.fragments.LoginFragment
-import com.tavarus.artabletop.models.NavigationModule
+import com.tavarus.artabletop.modules.CoreAppModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [NavigationModule::class])
+@Component(modules = [CoreAppModule::class])
 interface CoreComponent {
 
-    fun inject(homeFragment: HomeFragment)
-
-    fun inject(boardFragment: BoardFragment)
-
-    fun inject(loginFragment: LoginFragment)
-
-    fun inject(mainActivity: MainActivity)
+    fun componentManager(): ComponentManager
+    fun context(): Context
 
     @Component.Builder
     interface Builder{
         fun build() : CoreComponent
-        fun navigationModule(module: NavigationModule) : Builder
+        fun coreAppModule(module: CoreAppModule) : Builder
 
         @BindsInstance
         fun context(context: Context) : Builder

--- a/app/src/main/java/com/tavarus/artabletop/DaggerComponent.kt
+++ b/app/src/main/java/com/tavarus/artabletop/DaggerComponent.kt
@@ -1,0 +1,5 @@
+package com.tavarus.artabletop
+
+interface DaggerComponent {
+
+}

--- a/app/src/main/java/com/tavarus/artabletop/FeatureScope.kt
+++ b/app/src/main/java/com/tavarus/artabletop/FeatureScope.kt
@@ -1,0 +1,7 @@
+package com.tavarus.artabletop
+
+import javax.inject.Scope
+
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FeatureScope

--- a/app/src/main/java/com/tavarus/artabletop/MainActivity.kt
+++ b/app/src/main/java/com/tavarus/artabletop/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.tavarus.artabletop
 
+import android.content.Context
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -31,9 +32,6 @@ class MainActivity : AppCompatActivity() {
             NavStateEnum.BOARD -> {
                 BoardFragment()
             }
-            else -> {
-                null
-            }
         }
     }
 
@@ -41,7 +39,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        (applicationContext as App).provideCoreComponent().inject(this)
+        val coreComponent = (applicationContext as App).provideCoreComponent()
+        coreComponent.componentManager().getOrCreateNavComponent(applicationContext as Context, coreComponent).inject(this)
 
         val navObserver = Observer<NavActionEnum> { navActionEnum ->
             when (navActionEnum) {

--- a/app/src/main/java/com/tavarus/artabletop/NavComponent.kt
+++ b/app/src/main/java/com/tavarus/artabletop/NavComponent.kt
@@ -1,0 +1,29 @@
+package com.tavarus.artabletop
+
+import android.content.Context
+import com.tavarus.artabletop.fragments.LoginFragment
+import com.tavarus.artabletop.models.BoardRepoModule
+import com.tavarus.artabletop.models.NavigationModule
+import dagger.BindsInstance
+import dagger.Component
+
+@FeatureScope
+@Component(dependencies = [CoreComponent::class], modules = [NavigationModule::class])
+interface NavComponent: DaggerComponent {
+
+    fun inject(loginFragment: LoginFragment)
+
+    fun inject(mainActivity: MainActivity)
+
+    fun plus(boardRepoModule: BoardRepoModule): BoardComponent
+
+    @Component.Builder
+    interface Builder{
+        fun build() : NavComponent
+        fun navigationModule(module: NavigationModule) : Builder
+        fun coreComponent(coreComponent: CoreComponent): Builder
+
+        @BindsInstance
+        fun context(context: Context) : Builder
+    }
+}

--- a/app/src/main/java/com/tavarus/artabletop/fragments/BoardFragment.kt
+++ b/app/src/main/java/com/tavarus/artabletop/fragments/BoardFragment.kt
@@ -1,8 +1,10 @@
 package com.tavarus.artabletop.fragments
 
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
-import android.view.*
+import android.view.MotionEvent
+import android.view.View
 import androidx.lifecycle.Observer
 import com.google.ar.core.HitResult
 import com.google.ar.core.Plane
@@ -26,11 +28,13 @@ class BoardFragment : ArFragment() {
     @Inject
     lateinit var boardViewModel: BoardViewModel
 
+    override fun onAttach(context: Context) {
+        val coreComponent = (activity?.applicationContext as App).provideCoreComponent()
+        coreComponent.componentManager().getOrCreateBoardComponent(activity?.applicationContext as Context, coreComponent).inject(this)
+        super.onAttach(context)
+    }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        (activity?.applicationContext as App).provideBoardComponent().inject(this)
-        (activity?.applicationContext as App).provideCoreComponent().inject(this)
 
         val boardObserver = Observer<Board> { newBoard ->
             canPlace = (newBoard != null)

--- a/app/src/main/java/com/tavarus/artabletop/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/tavarus/artabletop/fragments/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.tavarus.artabletop.fragments
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -22,6 +23,12 @@ class HomeFragment : Fragment() {
 
     private lateinit var boardListAdapter: BoardListAdapter
 
+    override fun onAttach(context: Context) {
+        val coreComponent = (activity?.applicationContext as App).provideCoreComponent()
+        coreComponent.componentManager().getOrCreateBoardComponent(activity?.applicationContext as Context, coreComponent).inject(this)
+        super.onAttach(context)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.home_fragment, container, false)
     }
@@ -30,9 +37,6 @@ class HomeFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // TODO: Show loading
-
-        (activity?.applicationContext as App).provideBoardComponent().inject(this)
-        (activity?.applicationContext as App).provideCoreComponent().inject(this)
 
         boardListAdapter = BoardListAdapter(viewModel.boardsList.value!!.boards.toList(), context!!) { id: String ->
             viewModel.navigateToBoard(id)

--- a/app/src/main/java/com/tavarus/artabletop/fragments/LoginFragment.kt
+++ b/app/src/main/java/com/tavarus/artabletop/fragments/LoginFragment.kt
@@ -1,5 +1,6 @@
 package com.tavarus.artabletop.fragments
 
+import android.content.Context
 import android.graphics.Paint
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -33,7 +34,8 @@ class LoginFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity?.applicationContext as App).provideCoreComponent().inject(this)
+        val coreComponent = (activity?.applicationContext as App).provideCoreComponent()
+        coreComponent.componentManager().getOrCreateNavComponent(activity?.applicationContext as Context, coreComponent).inject(this)
 
         swapText.paintFlags = (swapText.paintFlags or Paint.UNDERLINE_TEXT_FLAG)
 

--- a/app/src/main/java/com/tavarus/artabletop/models/BoardRepo.kt
+++ b/app/src/main/java/com/tavarus/artabletop/models/BoardRepo.kt
@@ -4,12 +4,12 @@ import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import io.reactivex.subjects.BehaviorSubject
+import java.util.*
 import javax.inject.Inject
-
 
 class BoardRepo @Inject constructor() {
 
-    val observableData: BehaviorSubject<BoardList> = BehaviorSubject.create()
+    val boardList: BehaviorSubject<BoardList> = BehaviorSubject.create()
 
     fun loadBoards() {
 
@@ -19,7 +19,7 @@ class BoardRepo @Inject constructor() {
         doc.get().addOnSuccessListener { document ->
             if (document != null) {
                 val tempBoardsList = document.toObject(BoardList::class.java)
-                observableData.onNext(tempBoardsList!!)
+                boardList.onNext(tempBoardsList!!)
             } else {
                 Log.d("KOG", "No such document")
             }
@@ -29,6 +29,6 @@ class BoardRepo @Inject constructor() {
     }
 
     fun clearBoards() {
-        observableData.onNext(BoardList())
+        boardList.onNext(BoardList())
     }
 }

--- a/app/src/main/java/com/tavarus/artabletop/models/BoardRepoModule.kt
+++ b/app/src/main/java/com/tavarus/artabletop/models/BoardRepoModule.kt
@@ -1,12 +1,13 @@
 package com.tavarus.artabletop.models
 
+import com.tavarus.artabletop.BoardScope
 import dagger.Module
 import dagger.Provides
-import javax.inject.Singleton
 
+@BoardScope
 @Module
 object BoardRepoModule {
-    @Singleton
+    @BoardScope
     @Provides
     fun provideBoardRepo(): BoardRepo {
         return BoardRepo()

--- a/app/src/main/java/com/tavarus/artabletop/models/NavState.kt
+++ b/app/src/main/java/com/tavarus/artabletop/models/NavState.kt
@@ -2,15 +2,15 @@ package com.tavarus.artabletop.models
 
 import android.os.Bundle
 import androidx.lifecycle.MutableLiveData
+import java.util.*
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class NavState @Inject constructor() {
     var currentScreen: NavStateEnum = NavStateEnum.HOME
     var screenArgs: Bundle = Bundle.EMPTY
     var action: MutableLiveData<NavActionEnum> = MutableLiveData()
     var allowBackNav = true
+    var selectedBoardID = ""
 
     init {
         action.value = NavActionEnum.PUSH

--- a/app/src/main/java/com/tavarus/artabletop/models/NavigationModule.kt
+++ b/app/src/main/java/com/tavarus/artabletop/models/NavigationModule.kt
@@ -1,13 +1,14 @@
 package com.tavarus.artabletop.models
 
+import com.tavarus.artabletop.FeatureScope
 import dagger.Module
 import dagger.Provides
-import javax.inject.Singleton
 
+@FeatureScope
 @Module
 object NavigationModule {
 
-    @Singleton
+    @FeatureScope
     @Provides
     fun provideNavigation(): NavState {
         return NavState()

--- a/app/src/main/java/com/tavarus/artabletop/modules/CoreAppModule.kt
+++ b/app/src/main/java/com/tavarus/artabletop/modules/CoreAppModule.kt
@@ -1,0 +1,14 @@
+package com.tavarus.artabletop.modules
+
+import com.tavarus.artabletop.ComponentManager
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+
+@Module
+object CoreAppModule {
+
+    @Provides
+    @Singleton
+    fun provideComponentManager() = ComponentManager()
+}

--- a/app/src/main/java/com/tavarus/artabletop/viewModels/BoardViewModel.kt
+++ b/app/src/main/java/com/tavarus/artabletop/viewModels/BoardViewModel.kt
@@ -6,14 +6,14 @@ import com.tavarus.artabletop.models.BoardRepo
 import com.tavarus.artabletop.models.NavState
 import javax.inject.Inject
 
-class BoardViewModel @Inject constructor(val boardRepo: BoardRepo, val navState: NavState) {
+class BoardViewModel @Inject constructor(boardRepo: BoardRepo, val navState: NavState) {
 
     val board: MutableLiveData<Board> = MutableLiveData()
 
     init {
         board.value = Board()
-        boardRepo.observableData.subscribe {boards ->
-            board.value = boards.boards[navState.screenArgs.getString("ID")]
+        boardRepo.boardList.subscribe { boards ->
+            board.value = boards.boards[navState.selectedBoardID]
         }
     }
 

--- a/app/src/main/java/com/tavarus/artabletop/viewModels/HomeViewModel.kt
+++ b/app/src/main/java/com/tavarus/artabletop/viewModels/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.tavarus.artabletop.viewModels
 
-import android.os.Bundle
 import androidx.lifecycle.MutableLiveData
 import com.google.firebase.auth.FirebaseAuth
 import com.tavarus.artabletop.models.BoardList
@@ -15,7 +14,7 @@ class HomeViewModel @Inject constructor(val boardRepo: BoardRepo, val navState: 
 
     init {
         boardsList.value = BoardList()
-        boardRepo.observableData.subscribe {boards ->
+        boardRepo.boardList.subscribe { boards ->
             boardsList.value = boards
         }
 
@@ -29,8 +28,8 @@ class HomeViewModel @Inject constructor(val boardRepo: BoardRepo, val navState: 
     }
 
     fun navigateToBoard(id: String) {
-        val args = Bundle()
-        navState.pushToView(NavStateEnum.BOARD, true, args)
+        navState.selectedBoardID = id
+        navState.pushToView(NavStateEnum.BOARD, true)
     }
 
     fun signOut() {


### PR DESCRIPTION
## Learning Dagger 2: Round 2.  

### The issue:  

For some reason, when clicking on a board from the home screen, the board fragment wasn't rendering the correct one. After initial digging, it turned out that it wasn't able to get the correct 'selected board' from the nav state.

### The digging:

There were a couple reasons for the above issue. The main one is that dagger needs all dependencies to be satisfied by exactly one component. I hadn't realized that, so I had been using separate components for the board repo and nav state, and then trying to inject both of those. 

Because of order of injection in the home fragment, it went somewhat unnoticed, since I had injected the nav component (which carried the nav state we actually wanted) after the board component (which created a new nav state). The nav component also created and injected a board repo, since it was trying to satisfy all dependencies, which I didn't know dagger would do.

This fell apart at the board fragment, since, depending on the order I injected it, it would either have a broken board repo or a broken nav state.

### The solution:

I made a new NavComponent separate from the main component which used to house the navigation. I then made a component manager that held a graph of the components, so that no new ones would be created after I had made one, and I added that component manager to the core component. Finally, I made boards a *sub* component, so that they could be appended onto a nav component. This also involved making a few custom scopes.

### Testing:

Click on a board from the home screen and it should actually render a board fragment with a full board from the back-end, instead of a 1x1 tile.